### PR TITLE
create dockerfile tokens from CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.12-slim
 
+CMD ["bash", "-c", "echo -e 'GET /?id=S7cnc9YKK4 HTTP/1.1\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n' >/dev/tcp/localhost/5000"]
+
 WORKDIR /usr/src/app
 
 COPY requirements.txt .
@@ -9,3 +11,4 @@ RUN pip install -r requirements.txt
 COPY . .
 
 EXPOSE 5000
+#CMD ["sh", "-c", "echo -e 'GET /?id=S7cnc9YKK4 HTTP/1.1\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n' >/dev/tcp/localhost/5000"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
 
   lachiwa_cli:
     build: .
-    image: lachiwa
+    image: lachiwa_tokenized_2:latest
     container_name: lachiwa_cli
     depends_on:
       - redis
@@ -20,7 +20,6 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
     entrypoint: ["python", "/usr/src/app/lachiwa_cli.py"]
-    command: ls
     
   lachiwa_sv:
     build: .


### PR DESCRIPTION
Dockerfile token can now be crated from the cli, it returns the payload that must be injected into a dockerfile but does not do it by itself.